### PR TITLE
fix(parser): Fix parser's error about multiple line comments

### DIFF
--- a/src/generator/parser.cc
+++ b/src/generator/parser.cc
@@ -72,9 +72,12 @@ bool Parser::parse(const std::string& proto_file, idl_info& info)
 
 		if ((state & PARSER_ST_COMMENT_MASK) == PARSER_ST_INSIDE_COMMENT)
 		{
-			if (this->check_multi_comments_end(line))
+			if (this->check_multi_comments_end(line)) 
+			{
 				state -= PARSER_ST_INSIDE_COMMENT;
-			//	state |= PARSER_ST_OUTSIDE_COMMENT_MASK;
+				//	state |= PARSER_ST_OUTSIDE_COMMENT_MASK;
+				if (line.empty()) continue;
+			}
 			else
 				continue;
 


### PR DESCRIPTION
When there is no extra character after the "*/" at the end of a multi-line comment, check_block_begin() function  will read an extra line of code which may not be properly parsed.

For example: In the following thrift IDL file, the  "other.thrift" line can't parsed correctly, so other.thrift file won't  be included.

```
/** comment
 * line1
 */
include "other.thrift"
```

However, the following file will be properly parsed by the original code.

```
/** comment
 * line1
 */

include "other.thrift"
```